### PR TITLE
Move arena tests into separate module

### DIFF
--- a/src/arena/dropless.rs
+++ b/src/arena/dropless.rs
@@ -1,12 +1,23 @@
 extern crate alloc;
 
-use alloc::alloc::{AllocError, Allocator, Global, Layout};
+use alloc::alloc::{
+  AllocError,
+  Allocator,
+  Global,
+  Layout,
+};
 use core::{
   cell::UnsafeCell,
-  ptr::{self, NonNull},
+  ptr::{
+    self,
+    NonNull,
+  },
 };
 
-use crate::{arena::chunk::Chunk as RawChunk, once::Once};
+use crate::{
+  arena::chunk::Chunk as RawChunk,
+  once::Once,
+};
 
 type Chunk<'arena, A> = RawChunk<&'arena A, u8, false>;
 
@@ -220,24 +231,5 @@ where
       new_layout.size(),
     );
     Ok(new_block)
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  #[test]
-  fn test_dropless_arena() {
-    let arena = DroplessArena::new(1024);
-    let string_layout = Layout::array::<u8>(10).unwrap();
-    let mut string_raw = arena.allocate_zeroed(string_layout).unwrap();
-    let string_slice = unsafe { string_raw.as_mut() };
-    string_slice.copy_from_slice(b"HelloWorld");
-
-    let str_ref = unsafe { core::str::from_utf8_unchecked(string_slice) };
-
-    assert_eq!(string_slice, b"HelloWorld");
-    assert_eq!(str_ref, "HelloWorld");
   }
 }

--- a/src/arena/mod.rs
+++ b/src/arena/mod.rs
@@ -1,3 +1,6 @@
 pub(crate) mod chunk;
 pub mod dropless;
 pub mod typed;
+
+#[cfg(test)]
+mod tests;

--- a/src/arena/tests.rs
+++ b/src/arena/tests.rs
@@ -1,0 +1,69 @@
+use super::{
+  dropless::DroplessArena,
+  typed::TypedArena,
+};
+use alloc::alloc::{
+  Allocator,
+  Layout,
+};
+use core::cell::Cell;
+
+#[test]
+fn dropless_arena_basic() {
+  let arena = DroplessArena::new(1024);
+  let layout = Layout::array::<u8>(10).unwrap();
+  let mut raw = arena.allocate_zeroed(layout).unwrap();
+  // SAFETY: raw is valid for 10 bytes
+  let slice = unsafe { raw.as_mut() };
+  slice.copy_from_slice(b"HelloWorld");
+  // SAFETY: slice contains valid utf8
+  let str_ref = unsafe { core::str::from_utf8_unchecked(slice) };
+  assert_eq!(slice, b"HelloWorld");
+  assert_eq!(str_ref, "HelloWorld");
+}
+
+#[test]
+fn dropless_arena_multiple_chunks() {
+  let arena = DroplessArena::new(8);
+  let layout = Layout::array::<u8>(8).unwrap();
+  let mut first = arena.allocate_zeroed(layout).unwrap();
+  // SAFETY: first is valid for 8 bytes
+  let first_slice = unsafe { first.as_mut() };
+  first_slice.copy_from_slice(b"ABCDEFGH");
+  let mut second = arena.allocate_zeroed(layout).unwrap();
+  // SAFETY: second is valid for 8 bytes
+  let second_slice = unsafe { second.as_mut() };
+  second_slice.copy_from_slice(b"IJKLMNOP");
+  assert_eq!(first_slice, b"ABCDEFGH");
+  assert_eq!(second_slice, b"IJKLMNOP");
+}
+
+struct DropCounter<'a>(&'a Cell<usize>);
+
+impl<'a> Drop for DropCounter<'a> {
+  fn drop(&mut self) {
+    let v = self.0.get();
+    self.0.set(v + 1);
+  }
+}
+
+#[test]
+fn typed_arena_drop() {
+  let arena = TypedArena::new(4);
+  let counter = Cell::new(0);
+  {
+    let _ = arena.alloc(DropCounter(&counter)).unwrap();
+    let _ = arena.alloc(DropCounter(&counter)).unwrap();
+    assert_eq!(counter.get(), 0);
+  }
+  drop(arena);
+  assert_eq!(counter.get(), 2);
+}
+
+#[test]
+fn typed_arena_multiple_chunks() {
+  let arena = TypedArena::new(1);
+  let a = arena.alloc(1u32).unwrap();
+  let b = arena.alloc(2u32).unwrap();
+  assert_eq!((*a, *b), (1, 2));
+}

--- a/src/arena/typed.rs
+++ b/src/arena/typed.rs
@@ -1,13 +1,24 @@
 extern crate alloc;
 
-use alloc::alloc::{AllocError, Allocator, Global, Layout};
+use alloc::alloc::{
+  AllocError,
+  Allocator,
+  Global,
+  Layout,
+};
 use core::{
   cell::UnsafeCell,
   mem,
-  ptr::{self, NonNull},
+  ptr::{
+    self,
+    NonNull,
+  },
 };
 
-use crate::{arena::chunk::Chunk as RawChunk, once::Once};
+use crate::{
+  arena::chunk::Chunk as RawChunk,
+  once::Once,
+};
 
 type Chunk<'arena, T, A> = RawChunk<&'arena A, T, true>;
 
@@ -187,33 +198,5 @@ where
     _new_layout: Layout,
   ) -> Result<NonNull<[u8]>, AllocError> {
     Err(AllocError)
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use core::cell::Cell;
-
-  struct DropCounter<'a>(&'a Cell<usize>);
-
-  impl<'a> Drop for DropCounter<'a> {
-    fn drop(&mut self) {
-      let v = self.0.get();
-      self.0.set(v + 1);
-    }
-  }
-
-  #[test]
-  fn typed_arena_drop() {
-    let arena = TypedArena::new(4);
-    let counter = Cell::new(0);
-    {
-      let _ = arena.alloc(DropCounter(&counter)).unwrap();
-      let _ = arena.alloc(DropCounter(&counter)).unwrap();
-      assert_eq!(counter.get(), 0);
-    }
-    drop(arena);
-    assert_eq!(counter.get(), 2);
   }
 }


### PR DESCRIPTION
## Summary
- move Dropless and Typed arena tests into a dedicated `arena::tests` module behind `cfg(test)`
- add extra coverage for multi-chunk allocation and drop behavior

## Testing
- `cargo +nightly test`

------
https://chatgpt.com/codex/tasks/task_e_6892319ac25483339e8a5569640b0732