### PR TITLE
Handle zero-sized types in arena

### DIFF
--- a/src/arena/tests.rs
+++ b/src/arena/tests.rs
@@ -67,3 +67,11 @@ fn typed_arena_multiple_chunks() {
   let b = arena.try_alloc(2u32).unwrap();
   assert_eq!((*a, *b), (1, 2));
 }
+
+#[test]
+fn typed_arena_zero_sized() {
+  let arena = TypedArena::new(1);
+  let a = arena.try_alloc(()).unwrap();
+  let b = arena.try_alloc(()).unwrap();
+  assert_eq!((*a, *b), ((), ()));
+}


### PR DESCRIPTION
## Summary
- avoid division by zero in `Chunk` by explicitly handling zero-sized types throughout allocation, deallocation, growth, and shrink
- add regression test ensuring `TypedArena` can allocate zero-sized values safely

## Testing
- `cargo +nightly test`


------
https://chatgpt.com/codex/tasks/task_e_6892fd8f683083339749561077719b5e